### PR TITLE
Normalize output format handling (-t) to match input (-f)

### DIFF
--- a/pancritic/filters.py
+++ b/pancritic/filters.py
@@ -147,16 +147,16 @@ def markdown_filter(body, engine):
     return body
 
 
-def pandoc_filter(body, input_format, output_format, standalone, engine, outputfile=None):
+def pandoc_filter(body, from_format, to_format, standalone, engine, outputfile=None):
     extra_args = ['-s'] if standalone else []
 
-    def panflute_filter(body, input_format, output_format, extra_args, outputfile):
+    def panflute_filter(body, from_format, to_format, extra_args, outputfile):
         from panflute import convert_text
-        return convert_text(body, input_format=input_format, output_format=output_format, extra_args=extra_args)
+        return convert_text(body, input_format=from_format, output_format=to_format, extra_args=extra_args)
 
-    def pypandoc_filter(body, input_format, output_format, extra_args, outputfile):
+    def pypandoc_filter(body, from_format, to_format, extra_args, outputfile):
         from pypandoc import convert_text
-        return convert_text(body, output_format, input_format, extra_args=extra_args, outputfile=outputfile)
+        return convert_text(body, to_format, from_format, extra_args=extra_args, outputfile=outputfile)
 
     engines = ('panflute', 'pypandoc') if engine == 'panflute' else ('pypandoc', 'panflute')
     engine_function = {
@@ -169,7 +169,7 @@ def pandoc_filter(body, input_format, output_format, standalone, engine, outputf
             # i != 0 means failing last time
             if i != 0:
                 print('Use {} instead.'.format(engine), file=sys.stderr)
-            return engine_function[engine](body, input_format, output_format, extra_args, outputfile)
+            return engine_function[engine](body, from_format, to_format, extra_args, outputfile)
         except:
             print('Cannot use {}.'.format(engine), file=sys.stderr)
 


### PR DESCRIPTION
Fixes #5.

There were a couple logic problems.

1. The results of processing the `--to` argument were getting clobbered by file name guessing
2. There were two variables being held with the target format, `args.to` and `output_format`. They were used in different places and it was possible for them to be out of sync, causing unexpected results.

This normalizes the whole mess on one variable (args.to_format) and handles setting it just like `--from` instead of ... differently. The only place other variables are used is in passing arguments to panflute, which apparently wants named arguments in a slightly different format.

I have **not** been able to test this very exhaustively with all the backends and situations that might be affected. Please proceed with caution on this one, and if something needs fixing I'd be happy to do it.

Depending on what order you merge this or #11 might need to be rebased before merging. Feel free to do ether one and I'll update the PR for the other.